### PR TITLE
Return structured data from task

### DIFF
--- a/tasks/run_scan.json
+++ b/tasks/run_scan.json
@@ -2,7 +2,8 @@
   "description": "Runs script on target node to detect xz vulnerability (CVE-2024-3094)",
   "supports_noop": false,
   "files": [
-    "xzscanner/files/detect.sh"
+    "xzscanner/files/detect.sh",
+    "bash_task_helper/files/task_helper.sh"
   ],
   "parameters": {}
 }

--- a/tasks/run_scan.sh
+++ b/tasks/run_scan.sh
@@ -3,5 +3,7 @@
 set -e
 
 declare PT__installdir
-echo "Command: ${PT__installdir}/xzscanner/files/detect.sh"
-${PT__installdir}/xzscanner/files/detect.sh 2>&1
+source "$PT__installdir/bash_task_helper/files/task_helper.sh"
+
+result=$(${PT__installdir}/xzscanner/files/detect.sh 2>&1)
+task-output-json "vulnerable?" $result


### PR DESCRIPTION
As a plan author I want to consume the result of the `xzscanner::run_scan` task. As such, using structured output for the task will allow me to interact with the data effectively. This commit modifies the task to return structured data such that a plan author can utilize the task more effeciently.